### PR TITLE
Fix display name usages

### DIFF
--- a/src/api/sensor.service.ts
+++ b/src/api/sensor.service.ts
@@ -55,7 +55,7 @@ export const SensorService = {
     return http.post(`/sensors/${mac}/star`).then((r) => r.data);
   },
 
-  updateSensorNickname(mac: string, displayName: string) {
+  updateSensorDisplayName(mac: string, displayName: string) {
     return http.patch(`/sensors/${mac}`, { displayName }).then((r) => r.data);
   },
   async getSensorById(id: string): Promise<Sensor> {

--- a/src/components/analytics/sensor-card.tsx
+++ b/src/components/analytics/sensor-card.tsx
@@ -25,7 +25,7 @@ export const SensorCard: React.FC<SensorCardProps> = ({
   // Map sensor properties to component props
   const sensorId = sensor._id || '';
   const sensorMac = sensor.mac;
-  const sensorNickname = sensor.displayName || '';
+  const sensorDisplayName = sensor.displayName || '';
   const sensorType = sensor.type;
   const sensorStatus = sensor.status;
   const sensorStarred = sensor.isStarred || false;
@@ -88,7 +88,7 @@ export const SensorCard: React.FC<SensorCardProps> = ({
           <div className="flex items-center gap-2 mb-1">
             <div className={`w-2 h-2 rounded-full ${sensorStatus === 'live' ? 'bg-success' : 'bg-danger'}`} />
             <span className="text-sm font-medium truncate">
-              {sensorNickname || sensorMac}
+              {sensorDisplayName || sensorMac}
             </span>
             <div className="ml-auto">
               <Button
@@ -108,9 +108,9 @@ export const SensorCard: React.FC<SensorCardProps> = ({
             </div>
           </div>
           
-          {(!isMobile || sensorNickname) && (
+          {(!isMobile || sensorDisplayName) && (
             <div className="text-xs text-default-500 truncate">
-              {sensorNickname ? sensorMac : ''}
+              {sensorDisplayName ? sensorMac : ''}
             </div>
           )}
           

--- a/src/components/analytics/sensor-list.tsx
+++ b/src/components/analytics/sensor-list.tsx
@@ -51,7 +51,7 @@ export const SensorList: React.FC<SensorListProps> = ({
     <div className="flex flex-col h-full">
       <div className="p-4 border-b border-divider">
         <Input
-          placeholder="Search by MAC or nickname"
+          placeholder="Search by MAC or display name"
           value={searchText}
           onValueChange={onSearch}
           startContent={<Icon icon="lucide:search" className="text-default-400" />}

--- a/src/components/analytics/solo-view.tsx
+++ b/src/components/analytics/solo-view.tsx
@@ -340,7 +340,7 @@ export const SoloView: React.FC = () => {
 
       addToast({
         title: "Display Name Updated",
-        description: `Sensor ${currentSensor.mac} nickname saved`,
+        description: `Sensor ${currentSensor.mac} display name saved`,
       });
     }
   };

--- a/src/components/visualization/chart-container.tsx
+++ b/src/components/visualization/chart-container.tsx
@@ -51,7 +51,7 @@ interface ChartContainerProps {
     mac: string;
     displayName?: string;
   };
-  onDisplayNameChange?: (nickname: string) => void;
+  onDisplayNameChange?: (displayName: string) => void;
   onToggleStar?: () => void;
   isStarred?: boolean;
   onOpenInNewTab?: () => void;

--- a/src/hooks/use-sensors.ts
+++ b/src/hooks/use-sensors.ts
@@ -76,8 +76,8 @@ export const useSensors = () => {
     dispatch(toggleSensorStar(sensorId));
   };
   
-  // Update sensor displayName
-  const handleUpdateNickname = (sensorId: string, displayName: string) => {
+  // Update sensor display name
+  const handleUpdateDisplayName = (sensorId: string, displayName: string) => {
     dispatch(updateSensorDisplayName({ mac: sensorId, displayName }));
   };
   
@@ -108,7 +108,7 @@ export const useSensors = () => {
     setFilters: handleFiltersChange,
     setSelectedSensorIds: handleMultiSelect,
     toggleSensorStar: handleToggleStar,
-    updateSensorNickname: handleUpdateNickname,
+    updateSensorDisplayName: handleUpdateDisplayName,
     fetchSensorData: handleSensorSelect,
     handleTimeRangeChange
   };

--- a/src/pages/analytics.tsx
+++ b/src/pages/analytics.tsx
@@ -111,7 +111,6 @@ export const AnalyticsPage: React.FC = () => {
     return sensors.map((sensor) => ({
       ...sensor,
       id: sensor._id,
-      nickname: sensor.displayName,
       starred: sensor.isStarred,
     }));
   }, [sensors]);
@@ -123,7 +122,7 @@ export const AnalyticsPage: React.FC = () => {
     /* search */
     if (filters.search.trim()) {
       const q = filters.search.toLowerCase();
-      list = list.filter((s) => s.mac.toLowerCase().includes(q) || (s.nickname ?? "").toLowerCase().includes(q));
+      list = list.filter((s) => s.mac.toLowerCase().includes(q) || (s.displayName ?? "").toLowerCase().includes(q));
     }
 
     /* sensor type */
@@ -534,7 +533,7 @@ export const AnalyticsPage: React.FC = () => {
                       className={`w-2 h-2 rounded-full ${currentSensor.status === "live" ? "bg-success" : "bg-danger"}`}
                     />
                     <span className="text-sm font-medium truncate max-w-[120px]">
-                      {currentSensor.nickname || currentSensor.mac}
+                      {currentSensor.displayName || currentSensor.mac}
                     </span>
                   </div>
                 )}
@@ -731,7 +730,7 @@ export const AnalyticsPage: React.FC = () => {
               {selectedSensorsForCompare.map((sensor) => (
                 <div key={sensor._id} className="flex items-center gap-2 p-2 border border-divider rounded-lg">
                   <div className={`w-2 h-2 rounded-full ${sensor.status === "live" ? "bg-success" : "bg-danger"}`} />
-                  <span className="text-sm">{sensor.nickname || sensor.mac}</span>
+                  <span className="text-sm">{sensor.displayName || sensor.mac}</span>
                   <Button isIconOnly size="sm" variant="light" onPress={() => handleRemoveCompare(sensor._id)}>
                     <Icon icon="lucide:x" width={14} />
                   </Button>
@@ -789,7 +788,7 @@ export const AnalyticsPage: React.FC = () => {
 
               <div className="p-4 border-b border-divider">
                 <Input
-                  placeholder="Search by MAC or nickname"
+                  placeholder="Search by MAC or display name"
                   value={filters.search}
                   onValueChange={handleSearchChange}
                   startContent={<Icon icon="lucide:search" className="text-default-400" />}

--- a/src/store/sensorsSlice.ts
+++ b/src/store/sensorsSlice.ts
@@ -62,9 +62,9 @@ export const toggleSensorStar = createAsyncThunk("sensors/toggleStar", async (ma
 });
 
 export const updateSensorDisplayName = createAsyncThunk(
-  "sensors/updateNickname",
+  "sensors/updateDisplayName",
   async ({ mac, displayName }: { mac: string; displayName: string }) => {
-    const res = await SensorService.updateSensorNickname(mac, displayName);
+    const res = await SensorService.updateSensorDisplayName(mac, displayName);
     return { mac, displayName, success: res.success };
   }
 );
@@ -337,7 +337,7 @@ const sensorSlice = createSlice({
       }
     });
 
-    /* nickname update --------------------------------- */
+    /* display name update --------------------------------- */
     builder.addCase(updateSensorDisplayName.fulfilled, (s, a) => {
       if (!a.payload.success) return;
       const idx = s.data.findIndex((se) => se.mac === a.payload.mac);

--- a/src/types/telemetry.ts
+++ b/src/types/telemetry.ts
@@ -10,7 +10,7 @@ export interface TelemetryPoint {
 export interface SensorTelemetryResponse {
   /** Mongo/ObjectId or DB primary key for the sensor */
   sensorId: string;
-  /** MAC address (helps the UI when nicknames are blank) */
+  /** MAC address (helps the UI when display names are blank) */
   mac: string;
   /** e.g. “temperature”, “humidity”, … — must match <SensorType> union */
   type: "temperature" | "humidity" | "pressure" | "battery" | "co2" | "light" | "motion" | "unknown";


### PR DESCRIPTION
## Summary
- replace old nickname prop usage with displayName
- rename nickname handlers
- adjust UI copy referring to nickname

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config)*

------
https://chatgpt.com/codex/tasks/task_e_6843db68eaf0832eb48e37ecb3b029b4